### PR TITLE
Making custom annotator optional again

### DIFF
--- a/deploy/mac_osx/xbrowse_settings/local_settings.py
+++ b/deploy/mac_osx/xbrowse_settings/local_settings.py
@@ -45,10 +45,11 @@ REFERENCE_SETTINGS = imp.load_source(
     os.path.dirname(os.path.realpath(__file__)) + '/reference_settings.py'
 )
 
-CUSTOM_ANNOTATOR_SETTINGS = imp.load_source(
-    'custom_annotation_settings',
-    os.path.dirname(os.path.realpath(__file__)) + '/custom_annotator_settings.py'
-)
+#CUSTOM_ANNOTATOR_SETTINGS = imp.load_source(
+#    'custom_annotation_settings',
+#    os.path.dirname(os.path.realpath(__file__)) + '/custom_annotator_settings.py'
+#)
+CUSTOM_ANNOTATOR_SETTINGS = None
 
 ANNOTATOR_SETTINGS = imp.load_source(
     'annotator_settings',

--- a/xbrowse_server/base/management/commands/load_resources.py
+++ b/xbrowse_server/base/management/commands/load_resources.py
@@ -7,9 +7,13 @@ from xbrowse_server.xbrowse_annotation_controls import CustomAnnotator
 
 class Command(BaseCommand):
     def handle(self, *args, **options):
-        print("Load dbNSFP.. ")
-        custom_annotator = CustomAnnotator(settings.CUSTOM_ANNOTATOR_SETTINGS)
-        custom_annotator.load()
+
+        if settings.CUSTOM_ANNOTATOR_SETTINGS is not None:
+            print("Load dbNSFP.. ")
+
+            # note that you could use mall.get_custom_annotator() here too
+            custom_annotator = CustomAnnotator(settings.CUSTOM_ANNOTATOR_SETTINGS)
+            custom_annotator.load()
 
         get_reference().load()
         mall.get_annotator().load()


### PR DESCRIPTION
The changes here make CustomAnnotator optional, so the macos install can install with a smaller footprint. 

Basically, you can use only the basic annotations from VEP if you use: 

    CUSTOM_ANNOTATOR_SETTINGS=None

in local_settings.py. 

The changes here shouldn't affect anything in production - if CUSTOM_ANNOTATOR_SETTINGS is set - unless you are using the files in `deploy/mac_osx/xbrowse_settings` somewhere else. 