### PR TITLE
Adding support for secondary datastore

### DIFF
--- a/xbrowse_server/analysis/diagnostic_search.py
+++ b/xbrowse_server/analysis/diagnostic_search.py
@@ -75,7 +75,7 @@ def get_gene_diangostic_info(family, gene_id, variant_filter=None):
     diagnostic_info._gene_phenotype_summary = get_gene_phenotype_summary(get_reference(), gene_id)
     diagnostic_info._gene_sequencing_summary = get_gene_sequencing_summary(get_coverage_store(), family, gene_id)
     diagnostic_info._variants = get_diagnostic_search_variants_in_family(
-        get_mall().variant_store,
+        get_mall(family.project.project_id).variant_store,
         family,
         gene_id,
         variant_filter

--- a/xbrowse_server/analysis/family_group.py
+++ b/xbrowse_server/analysis/family_group.py
@@ -11,7 +11,7 @@ def get_variants_in_gene(family_group, gene_id, variant_filter=None, quality_fil
     """
     variants_by_family = []
     for family in family_group.get_families():
-        variant_list = list(get_mall().variant_store.get_variants_in_gene(
+        variant_list = list(get_mall(family.project.project_id).variant_store.get_variants_in_gene(
             family.project.project_id,
             family.family_id,
             gene_id,

--- a/xbrowse_server/analysis/project.py
+++ b/xbrowse_server/analysis/project.py
@@ -15,7 +15,7 @@ def inheritance_matrix_for_gene(project, gene_id):
     variant_filter = get_default_variant_filter('moderate_impact', mall.get_annotator().reference_population_slugs)
     quality_filter = get_default_quality_filter('high_quality', mall.get_annotator().reference_population_slugs)
     matrix = get_family_matrix_for_gene(
-        get_mall(),
+        get_mall(project.project_id),
         [f.xfamily() for f in project.get_active_families()],
         gene_id,
         variant_filter,
@@ -28,7 +28,7 @@ def get_variants_in_gene(project, gene_id, variant_filter=None, quality_filter=N
     """
     Get all the variants in a gene, but filter out quality_filter genotypes
     """
-    variant_list = get_project_datastore().get_project_variants_in_gene(project.project_id, gene_id, variant_filter=variant_filter)
+    variant_list = get_project_datastore(project.project_id).get_project_variants_in_gene(project.project_id, gene_id, variant_filter=variant_filter)
     variant_list = search_utils.filter_gene_variants_by_variant_filter(variant_list, gene_id, variant_filter)
     return variant_list
 
@@ -39,7 +39,7 @@ def get_knockouts_in_gene(project, gene_id, quality_filter=None):
     """
     indiv_id_list = [i.indiv_id for i in project.get_individuals()]
     variant_filter = get_default_variant_filter('high_impact')
-    variant_list = get_project_datastore().get_project_variants_in_gene(
+    variant_list = get_project_datastore(project.project_id).get_project_variants_in_gene(
         project.project_id,
         gene_id,
         variant_filter=variant_filter,

--- a/xbrowse_server/api/utils.py
+++ b/xbrowse_server/api/utils.py
@@ -255,7 +255,7 @@ def calculate_cohort_gene_search(cohort, search_spec):
 
     genes = []
     for gene_id, indivs_with_inheritance, gene_variation in cohort_get_genes_with_inheritance(
-        get_datastore(),
+        get_datastore(cohort.project.project_id),
         get_reference(),
         xcohort,
         search_spec.inheritance_mode,
@@ -316,7 +316,7 @@ def calculate_mendelian_variant_search(search_spec, xfamily):
     if search_spec.search_mode == 'standard_inheritance':
 
         variants = list(get_variants_with_inheritance_mode(
-            get_mall(),
+            get_mall(xfamily.project_id),
             xfamily,
             search_spec.inheritance_mode,
             variant_filter=search_spec.variant_filter,
@@ -326,7 +326,7 @@ def calculate_mendelian_variant_search(search_spec, xfamily):
     elif search_spec.search_mode == 'custom_inheritance':
 
         variants = list(get_variants_family(
-            get_datastore(),
+            get_datastore(xfamily.project_id),
             xfamily,
             genotype_filter=search_spec.genotype_inheritance_filter,
             variant_filter=search_spec.variant_filter,
@@ -336,7 +336,7 @@ def calculate_mendelian_variant_search(search_spec, xfamily):
     elif search_spec.search_mode == 'gene_burden':
 
         gene_stream = get_genes_family(
-            get_datastore(),
+            get_datastore(xfamily.project_id),
             get_reference(),
             xfamily,
             burden_filter=search_spec.gene_burden_filter,
@@ -349,7 +349,7 @@ def calculate_mendelian_variant_search(search_spec, xfamily):
     elif search_spec.search_mode == 'allele_count':
 
         variants = list(get_variants_allele_count(
-            get_datastore(),
+            get_datastore(xfamily.project_id),
             xfamily,
             search_spec.allele_count_filter,
             variant_filter=search_spec.variant_filter,
@@ -358,7 +358,7 @@ def calculate_mendelian_variant_search(search_spec, xfamily):
 
     elif search_spec.search_mode == 'all_variants':
         variants = list(get_variants_family(
-            get_datastore(),
+            get_datastore(xfamily.project_id),
             xfamily,
             variant_filter=search_spec.variant_filter,
             quality_filter=search_spec.genotype_quality_filter,
@@ -377,7 +377,7 @@ def calculate_combine_mendelian_families(family_group, search_spec):
 
     genes = []
     for gene_id, family_id_list in get_families_by_gene(
-        get_mall(),
+        get_mall(family_group.project.project_id),
         xfamilygroup,
         search_spec.inheritance_mode,
         search_spec.variant_filter,

--- a/xbrowse_server/api/views.py
+++ b/xbrowse_server/api/views.py
@@ -112,10 +112,10 @@ def mendelian_variant_search_spec(request):
         response['Content-Disposition'] = 'attachment; filename="xbrowse_results_{}.csv"'.format(search_hash)
         writer = csv.writer(response)
         indiv_ids = family.indiv_ids_with_variant_data()
-        headers = xbrowse_displays.get_variant_display_headers(get_mall(), project, indiv_ids)
+        headers = xbrowse_displays.get_variant_display_headers(get_mall(project.project_id), project, indiv_ids)
         writer.writerow(headers)
         for variant in variants:
-            fields = xbrowse_displays.get_display_fields_for_variant(get_mall(), project, variant, indiv_ids)
+            fields = xbrowse_displays.get_display_fields_for_variant(get_mall(project.project_id), project, variant, indiv_ids)
             writer.writerow(fields)
         return response
 
@@ -253,7 +253,7 @@ def cohort_gene_search_variants(request):
     if not error:
 
         indivs_with_inheritance, gene_variation = cohort_search.get_individuals_with_inheritance_in_gene(
-            get_datastore(),
+            get_datastore(project.project_id),
             get_reference(),
             cohort.xcohort(),
             inheritance_mode,
@@ -316,7 +316,7 @@ def family_variant_annotation(request):
             return HttpResponse('unauthorized')
 
     if not error:
-        variant = get_datastore().get_single_variant(
+        variant = get_datastore(project.project_id).get_single_variant(
             family.project.project_id,
             family.family_id,
             int(request.GET['xpos']),
@@ -383,7 +383,7 @@ def add_family_search_flag(request):
 
     if not error:
         flag.save()
-        variant = get_datastore().get_single_variant(family.project.project_id, family.family_id,
+        variant = get_datastore(project.project_id).get_single_variant(family.project.project_id, family.family_id,
             xpos, ref, alt )
         api_utils.add_extra_info_to_variant(get_reference(), family, variant)
 
@@ -426,7 +426,7 @@ def add_variant_note(request):
         if family:
             note.family = family
             note.save()
-        variant = get_datastore().get_single_variant(
+        variant = get_datastore(project.project_id).get_single_variant(
             project.project_id,
             family.family_id,
             form.cleaned_data['xpos'],
@@ -467,7 +467,7 @@ def edit_variant_tags(request):
                 ref=form.cleaned_data['ref'],
                 alt=form.cleaned_data['alt'],
             )
-        variant = get_datastore().get_single_variant(
+        variant = get_datastore(project.project_id).get_single_variant(
             project.project_id,
             family.family_id,
             form.cleaned_data['xpos'],
@@ -577,7 +577,7 @@ def combine_mendelian_families_variants(request):
     form = api_forms.CombineMendelianFamiliesVariantsForm(request.GET)
     if form.is_valid():
         variants_grouped = get_variants_by_family_for_gene(
-            get_mall(),
+            get_mall(project.project_id),
             [f.xfamily() for f in form.cleaned_data['families']],
             form.cleaned_data['inheritance_mode'],
             form.cleaned_data['gene_id'],

--- a/xbrowse_server/base/lookups.py
+++ b/xbrowse_server/base/lookups.py
@@ -17,7 +17,7 @@ def get_saved_variants_for_family(family):
     couldntfind = []
     variant_tuples = {(v.xpos, v.ref, v.alt) for v in search_flags}
     for variant_t in variant_tuples:
-        variant = get_datastore().get_single_variant(
+        variant = get_datastore(family.project.project_id).get_single_variant(
             family.project.project_id,
             family.family_id,
             variant_t[0],
@@ -61,7 +61,7 @@ def get_saved_variants_for_family(family):
 def get_variants_from_note_tuples(project, note_tuples):
     variants = []
     for note_t in note_tuples:
-        variant = get_datastore().get_single_variant(
+        variant = get_datastore(project.project_id).get_single_variant(
             project.project_id,
             note_t[3],
             note_t[0],
@@ -104,7 +104,7 @@ def get_causal_variants_for_project(project):
     variant_t_list = [(v.xpos, v.ref, v.alt, v.family.family_id) for v in CausalVariant.objects.filter(family__project=project)]
     variants = []
     for xpos, ref, alt, family_id in variant_t_list:
-        variant = get_datastore().get_single_variant(
+        variant = get_datastore(project.project_id).get_single_variant(
             project.project_id,
             family_id,
             xpos,

--- a/xbrowse_server/base/management/commands/batch_family_fileset.py
+++ b/xbrowse_server/base/management/commands/batch_family_fileset.py
@@ -36,7 +36,7 @@ class Command(BaseCommand):
         family_results = {}
         for family in families:
             family_results[family] = list(get_variants_with_inheritance_mode(
-                get_mall(),
+                get_mall(project_id),
                 family.xfamily(),
                 inheritance_mode,
                 variant_filter=variant_filter,

--- a/xbrowse_server/base/management/commands/check_for_missing_variants.py
+++ b/xbrowse_server/base/management/commands/check_for_missing_variants.py
@@ -46,7 +46,7 @@ class Command(BaseCommand):
                     for variant in vcf_stuff.iterate_vcf(f):
                         all_counter += 1
                         try:
-                            get_mall().annotator.get_annotation(variant.xpos, variant.ref, variant.alt)
+                            get_mall(project_id).annotator.get_annotation(variant.xpos, variant.ref, variant.alt)
                         except ValueError, e:
                             not_found_counter += 1
                             if len(not_found_variants) < 30:

--- a/xbrowse_server/base/management/commands/generate_variant_report.py
+++ b/xbrowse_server/base/management/commands/generate_variant_report.py
@@ -236,7 +236,7 @@ class Command(BaseCommand):
                 chrom, pos = genomeloc.get_chr_pos(xpos)
                 ref = variant_tag.ref
                 for alt in [variant_tag.alt]:  
-                    v = get_mall().variant_store.get_single_variant(project_id, individual.family.family_id, xpos, ref, alt) 
+                    v = get_mall(project_id).variant_store.get_single_variant(project_id, individual.family.family_id, xpos, ref, alt)
                     if v is None:
                         raise ValueError("Couldn't find variant in variant store for: %s, %s, %s %s %s %s" % (project_id, individual.family.family_id, xpos, ref, alt, variant_tag.toJSON()))
 

--- a/xbrowse_server/base/management/commands/reload_family.py
+++ b/xbrowse_server/base/management/commands/reload_family.py
@@ -34,7 +34,7 @@ class Command(BaseCommand):
                     continue
 
                 # delete this family
-                get_datastore().delete_family(project_id, family_id)
+                get_datastore(project_id).delete_family(project_id, family_id)
 
                 families_to_load.append(family)
                 # reload family

--- a/xbrowse_server/base/models.py
+++ b/xbrowse_server/base/models.py
@@ -436,10 +436,10 @@ class Family(models.Model):
     def get_data_status(self):
         if not self.has_variant_data():
             return 'no_variants'
-        elif not get_datastore().family_exists(self.project.project_id, self.family_id):
+        elif not get_datastore(self.project.project_id).family_exists(self.project.project_id, self.family_id):
             return 'not_loaded'
         else:
-            return get_datastore().get_family_status(self.project.project_id, self.family_id)
+            return get_datastore(self.project.project_id).get_family_status(self.project.project_id, self.family_id)
 
     def get_analysis_status(self):
         return self.analysis_status
@@ -615,10 +615,10 @@ class Cohort(models.Model):
     def get_data_status(self):
         if not self.has_variant_data():
             return 'no_variants'
-        elif not get_datastore().family_exists(self.project.project_id, self.cohort_id):
+        elif not get_datastore(self.project.project_id).family_exists(self.project.project_id, self.cohort_id):
             return 'not_loaded'
         else:
-            return get_datastore().get_family_status(self.project.project_id, self.cohort_id)
+            return get_datastore(self.project.project_id).get_family_status(self.project.project_id, self.cohort_id)
 
     def is_loaded(self):
         return self.get_data_status() in ['loaded', 'no_variants']
@@ -886,7 +886,7 @@ class FamilySearchFlag(models.Model):
         return json.dumps(self.to_dict())
 
     def x_variant(self):
-        v = get_datastore().get_single_variant(self.family.project.project_id, self.family.family_id, self.xpos, self.ref, self.alt)
+        v = get_datastore(self.family.project.project_id).get_single_variant(self.family.project.project_id, self.family.family_id, self.xpos, self.ref, self.alt)
         return v
 
 

--- a/xbrowse_server/base/views/family_views.py
+++ b/xbrowse_server/base/views/family_views.py
@@ -342,7 +342,7 @@ def edit_family_cause(request, project_id, family_id):
 
     variants = []
     for c in causal_variants:
-        variants.append(get_datastore().get_single_variant(project_id, family_id, c.xpos, c.ref, c.alt))
+        variants.append(get_datastore(project_id).get_single_variant(project_id, family_id, c.xpos, c.ref, c.alt))
 
     return render(request, 'family/edit_cause.html', {
         'project': project,
@@ -409,7 +409,7 @@ def family_variant_view(request, project_id, family_id):
     except:
         return HttpResponse('Invalid View')
 
-    variant = get_datastore().get_single_variant(project_id, family_id, xpos, ref, alt)
+    variant = get_datastore(project_id).get_single_variant(project_id, family_id, xpos, ref, alt)
     add_extra_info_to_variants_family(get_reference(), family, [variant])
 
     return render(request, 'family/family_variant_view.html', {

--- a/xbrowse_server/sample_management.py
+++ b/xbrowse_server/sample_management.py
@@ -100,7 +100,7 @@ def delete_project(project_id):
     Delete a project and perform any cleanup (ie. deleting from datastore and removing temp files)
     """
     project = Project.objects.get(project_id=project_id)
-    get_mall().variant_store.delete_project(project_id)
+    get_mall(project_id).variant_store.delete_project(project_id)
     project.individual_set.all().delete()
     project.family_set.all().delete()
     project.delete()
@@ -114,7 +114,7 @@ def delete_family(project_id, family_id):
     for individual in family.get_individuals():
         individual.family = None
         individual.save()
-    get_mall().variant_store.delete_family(project_id, family_id)
+    get_mall(project_id).variant_store.delete_family(project_id, family_id)
     family.delete()
 
 

--- a/xbrowse_server/xbrowse_controls.py
+++ b/xbrowse_server/xbrowse_controls.py
@@ -38,7 +38,7 @@ def clean_project(project_id):
     individuals = project.get_individuals()
 
     # datastore
-    get_mall().variant_store.delete_project(project_id)
+    get_mall(project_id).variant_store.delete_project(project_id)
 
     # coverage store
     for individual in individuals:
@@ -88,7 +88,7 @@ def load_variants_for_family_list(project, families, vcf_file):
         })
 
     # add all families from this vcf to the datastore
-    get_mall().variant_store.add_family_set(family_list)
+    get_mall(project.project_id).variant_store.add_family_set(family_list)
 
     # create the VCF ID map
     vcf_id_map = {}
@@ -99,7 +99,7 @@ def load_variants_for_family_list(project, families, vcf_file):
 
     # load them all into the datastore
     family_tuple_list = [(f['project_id'], f['family_id']) for f in family_list]
-    get_mall().variant_store.load_family_set(
+    get_mall(project.project_id).variant_store.load_family_set(
         vcf_file,
         family_tuple_list,
         reference_populations=project.get_reference_population_slugs(),
@@ -123,7 +123,7 @@ def load_variants_for_cohort_list(project, cohorts):
             })
 
         # add all families from this vcf to the datastore
-        get_mall().variant_store.add_family_set(family_list)
+        get_mall(project.project_id).variant_store.add_family_set(family_list)
 
         vcf_files = cohort.get_vcf_files()
 
@@ -136,7 +136,7 @@ def load_variants_for_cohort_list(project, cohorts):
         # load them all into the datastore
         for vcf_file in vcf_files:
             family_tuple_list = [(f['project_id'], f['family_id']) for f in family_list]
-            get_mall().variant_store.load_family_set(
+            get_mall(project.project_id).variant_store.load_family_set(
                 vcf_file.path(),
                 family_tuple_list,
                 reference_populations=project.get_reference_population_slugs(),
@@ -160,7 +160,7 @@ def load_project_variants(project_id, force_annotations=False, ignore_csq_in_vcf
 
     # batch load families by VCF file
     for vcf_file, families in project.families_by_vcf().items():
-        families = [f for f in families if get_mall().variant_store.get_family_status(project_id, f.family_id) != 'loaded']
+        families = [f for f in families if get_mall(project.project_id).variant_store.get_family_status(project_id, f.family_id) != 'loaded']
         for i in xrange(0, len(families), settings.FAMILY_LOAD_BATCH_SIZE):
             print(date.strftime(datetime.now(), "%m/%d/%Y %H:%M:%S  -- loading project: " + project_id + " - families batch %d - %d families" % (i, len(families[i:i+settings.FAMILY_LOAD_BATCH_SIZE])) ))
             load_variants_for_family_list(project, families[i:i+settings.FAMILY_LOAD_BATCH_SIZE], vcf_file)
@@ -169,7 +169,7 @@ def load_project_variants(project_id, force_annotations=False, ignore_csq_in_vcf
     print(date.strftime(datetime.now(), "%m/%d/%Y %H:%M:%S  -- loading project: " + project_id + " - cohorts"))
     # TODO: load cohorts and families together
     for vcf_file, cohorts in project.cohorts_by_vcf().items():
-        cohorts = [c for c in cohorts if get_mall().variant_store.get_family_status(project_id, c.cohort_id) != 'loaded']
+        cohorts = [c for c in cohorts if get_mall(project.project_id).variant_store.get_family_status(project_id, c.cohort_id) != 'loaded']
         for i in xrange(0, len(cohorts), settings.FAMILY_LOAD_BATCH_SIZE):
             print "Loading project %s - cohorts: %s" % (project_id, cohorts[i:i+settings.FAMILY_LOAD_BATCH_SIZE])
             load_variants_for_cohort_list(project, cohorts[i:i+settings.FAMILY_LOAD_BATCH_SIZE])
@@ -195,13 +195,13 @@ def load_project_datastore(project_id):
     """
     print(date.strftime(datetime.now(), "%m/%d/%Y %H:%M:%S  -- starting load_project_datastore: " + project_id))
     project = Project.objects.get(project_id=project_id)
-    get_project_datastore().delete_project_store(project_id)
-    get_project_datastore().add_project(project_id)
+    get_project_datastore(project_id).delete_project_store(project_id)
+    get_project_datastore(project_id).add_project(project_id)
     for vcf_file in project.get_all_vcf_files():
         project_indiv_ids = [i.indiv_id for i in project.get_individuals()]
         vcf_ids = vcf_file.sample_id_list()
         indiv_id_list = [i for i in project_indiv_ids if i in vcf_ids]
-        get_project_datastore().add_variants_to_project_from_vcf(
+        get_project_datastore(project_id).add_variants_to_project_from_vcf(
             vcf_file.file_handle(),
             project_id,
             indiv_id_list=indiv_id_list


### PR DESCRIPTION
This allows you to use a second MongoDatastore from a different database connection, for select projects. To enable, add the following lines to local_settings.py: 

    SECONDARY_DATASTORE_PROJECTS = [
        '1kg2'
    ]
    
    SECONDARY_DATASTORE_PORT =  27018
    _secondary_conn = pymongo.Connection(port=SECONDARY_DATASTORE_PORT)
    SECONDARY_DATASTORE_DB = _secondary_conn['xbrowse_datastore']
    SECONDARY_POPULATION_DATASTORE_DB = _secondary_conn['xbrowse_pop_datastore']

Then, if you run a second `mongod` on port 27018, the second mongo will be used for project `1kg2`. 

Important: you must add '1kg2' to `SECONDARY_DATASTORE_PROJECTS` *before* yo load any of its data. 

Here's how to replicate this locally on your mac install: 

0. Run a new mongodb: 

    mongod --dbpath [new db path] --storageEngine wiredTiger --port 27018

0. Create a new project directory. Copy the 1kg project directory, and edit project_id to be `1kg2`. 

0. Add the above lines to local_settings.py

0. Add project: 
    ./manage.py add_project 1kg2
    ./manage.py load_project_dir 1kg2 /path/to/1kg2/directory
    ./manage.py load_project 1kg2

When that's done, compare some searches in 1kg and 1kg2 - they should return the same results! For fun, here's the db footprint: 

    (xbrowse)Brett-Thomas:xbrowse bt$ mongo --port 27018
    MongoDB shell version: 3.0.2
    connecting to: 127.0.0.1:27018/test
    > use xbrowse_datastore
    switched to db xbrowse_datastore
    > db.stats()
    {
      "db" : "xbrowse_datastore",
      "collections" : 14,
      "objects" : 523249,
      "avgObjSize" : 681.5896886568345,
      "dataSize" : 356641123,
      "storageSize" : 95858688,        # <--- New storage size
      "numExtents" : 0,
      "indexes" : 62,
      "indexSize" : 45842432,
      "ok" : 1
    }

    Brett-Thomas:xbrowse bt$ mongo
    MongoDB shell version: 3.0.2
    connecting to: test
    > use xbrowse_datastore
    switched to db xbrowse_datastore
    > db.stats()
    {
      "db" : "xbrowse_datastore",
      "collections" : 16,
      "objects" : 523388,
      "avgObjSize" : 710.7050906784259,
      "dataSize" : 371974516,
      "storageSize" : 558284800,       # <---  Old storage size 
      "numExtents" : 101,
      "indexes" : 62,
      "indexSize" : 166970272,
      "fileSize" : 2080374784,
      "nsSizeMB" : 16,
      "dataFileVersion" : {
        "major" : 4,
        "minor" : 5
      },
      "ok" : 1
    }