### PR TITLE
Fix for transcript choice of CAPN3 vs. RP11-164J13.1

### DIFF
--- a/test/annotation/test_vep_annotations.py
+++ b/test/annotation/test_vep_annotations.py
@@ -8,18 +8,18 @@ class VepAnnotationsTests(unittest.TestCase):
 
     def test_get_worst_vep_annotation_index(self):
         annotations = [
-            {'Feature_type': 'Transcript', 'GMAF': '', 'Feature': 'ENST00000479049', 'Consequence': 'non_coding_transcript_exon_variant', 'Protein_position': '', 'Gene': 'ENSG00000135636', 'STRAND': '1', 'CANONICAL': ''},
-            {'Feature_type': 'Transcript', 'GMAF': '', 'Feature': 'ENST00000258104', 'Consequence': 'stop_gained', 'Protein_position': '1968', 'Gene': 'ENSG00000135636', 'STRAND': '1', 'CANONICAL': ''},
-            {'Feature_type': 'Transcript', 'GMAF': '', 'Feature': 'ENST00000394120', 'Consequence': 'stop_gained', 'Protein_position': '1969', 'Gene': 'ENSG00000135636', 'STRAND': '1', 'CANONICAL': ''},
-            {'Feature_type': 'Transcript', 'GMAF': '', 'Feature': 'ENST00000409366', 'Consequence': 'stop_gained', 'Protein_position': '1990', 'Gene': 'ENSG00000135636', 'STRAND': '1', 'CANONICAL': ''},
-            {'Feature_type': 'Transcript', 'GMAF': '', 'Feature': 'ENST00000409582', 'Consequence': 'stop_gained', 'Protein_position': '2006', 'Gene': 'ENSG00000135636', 'STRAND': '1', 'CANONICAL': ''},
-            {'Feature_type': 'Transcript', 'GMAF': '', 'Feature': 'ENST00000409651', 'Consequence': 'stop_gained', 'Protein_position': '2000', 'Gene': 'ENSG00000135636', 'STRAND': '1', 'CANONICAL': ''},
-            {'Feature_type': 'Transcript', 'GMAF': '', 'Feature': 'ENST00000409744', 'Consequence': 'stop_gained', 'Protein_position': '1976', 'Gene': 'ENSG00000135636', 'STRAND': '1', 'CANONICAL': ''},
-            {'Feature_type': 'Transcript', 'GMAF': '', 'Feature': 'ENST00000409762', 'Consequence': 'stop_gained', 'Protein_position': '1985', 'Gene': 'ENSG00000135636', 'STRAND': '1', 'CANONICAL': ''},
-            {'Feature_type': 'Transcript', 'GMAF': '', 'Feature': 'ENST00000410020', 'Consequence': 'stop_gained', 'Protein_position': '2007', 'Gene': 'ENSG00000135636', 'STRAND': '1', 'CANONICAL': 'YES'},
-            {'Feature_type': 'Transcript', 'GMAF': '', 'Feature': 'ENST00000410041', 'Consequence': 'stop_gained', 'Protein_position': '1986', 'Gene': 'ENSG00000135636', 'STRAND': '1', 'CANONICAL': ''},
-            {'Feature_type': 'Transcript', 'GMAF': '', 'Feature': 'ENST00000413539', 'Consequence': 'stop_gained', 'Protein_position': '1999', 'Gene': 'ENSG00000135636', 'STRAND': '1', 'CANONICAL': ''},
-            {'Feature_type': 'Transcript', 'GMAF': '', 'Feature': 'ENST00000429174', 'Consequence': 'stop_gained', 'Protein_position': '1989', 'Gene': 'ENSG00000135636', 'STRAND': '1', 'CANONICAL': ''},
+            {'Feature_type': 'Transcript', 'BIOTYPE': 'other', 'GMAF': '', 'Feature': 'ENST00000479049', 'Consequence': 'non_coding_transcript_exon_variant', 'Protein_position': '', 'Gene': 'ENSG00000135636', 'STRAND': '1', 'CANONICAL': ''},
+            {'Feature_type': 'Transcript', 'BIOTYPE': 'other', 'GMAF': '', 'Feature': 'ENST00000258104', 'Consequence': 'stop_gained', 'Protein_position': '1968', 'Gene': 'ENSG00000135636', 'STRAND': '1', 'CANONICAL': ''},
+            {'Feature_type': 'Transcript', 'BIOTYPE': 'other', 'GMAF': '', 'Feature': 'ENST00000394120', 'Consequence': 'stop_gained', 'Protein_position': '1969', 'Gene': 'ENSG00000135636', 'STRAND': '1', 'CANONICAL': ''},
+            {'Feature_type': 'Transcript', 'BIOTYPE': 'other', 'GMAF': '', 'Feature': 'ENST00000409366', 'Consequence': 'stop_gained', 'Protein_position': '1990', 'Gene': 'ENSG00000135636', 'STRAND': '1', 'CANONICAL': ''},
+            {'Feature_type': 'Transcript', 'BIOTYPE': 'other', 'GMAF': '', 'Feature': 'ENST00000409582', 'Consequence': 'stop_gained', 'Protein_position': '2006', 'Gene': 'ENSG00000135636', 'STRAND': '1', 'CANONICAL': ''},
+            {'Feature_type': 'Transcript', 'BIOTYPE': 'other', 'GMAF': '', 'Feature': 'ENST00000409651', 'Consequence': 'stop_gained', 'Protein_position': '2000', 'Gene': 'ENSG00000135636', 'STRAND': '1', 'CANONICAL': ''},
+            {'Feature_type': 'Transcript', 'BIOTYPE': 'other', 'GMAF': '', 'Feature': 'ENST00000409744', 'Consequence': 'stop_gained', 'Protein_position': '1976', 'Gene': 'ENSG00000135636', 'STRAND': '1', 'CANONICAL': ''},
+            {'Feature_type': 'Transcript', 'BIOTYPE': 'other', 'GMAF': '', 'Feature': 'ENST00000409762', 'Consequence': 'stop_gained', 'Protein_position': '1985', 'Gene': 'ENSG00000135636', 'STRAND': '1', 'CANONICAL': ''},
+            {'Feature_type': 'Transcript', 'BIOTYPE': 'other', 'GMAF': '', 'Feature': 'ENST00000410020', 'Consequence': 'stop_gained', 'Protein_position': '2007', 'Gene': 'ENSG00000135636', 'STRAND': '1', 'CANONICAL': 'YES'},
+            {'Feature_type': 'Transcript', 'BIOTYPE': 'other', 'GMAF': '', 'Feature': 'ENST00000410041', 'Consequence': 'stop_gained', 'Protein_position': '1986', 'Gene': 'ENSG00000135636', 'STRAND': '1', 'CANONICAL': ''},
+            {'Feature_type': 'Transcript', 'BIOTYPE': 'other', 'GMAF': '', 'Feature': 'ENST00000413539', 'Consequence': 'stop_gained', 'Protein_position': '1999', 'Gene': 'ENSG00000135636', 'STRAND': '1', 'CANONICAL': ''},
+            {'Feature_type': 'Transcript', 'BIOTYPE': 'other', 'GMAF': '', 'Feature': 'ENST00000429174', 'Consequence': 'stop_gained', 'Protein_position': '1989', 'Gene': 'ENSG00000135636', 'STRAND': '1', 'CANONICAL': ''},
         ]
 
         # convert keys to lower case
@@ -48,12 +48,19 @@ class VepAnnotationsTests(unittest.TestCase):
         self.assertEqual(get_worst_vep_annotation_index(annotations), 1)
         self.assertFalse(annotations[1]['canonical'])
 
+        # test protein coding filter
+        annotations[6]['BIOTYPE'] = 'protein_coding'
+        self.assertEqual(get_worst_vep_annotation_index(annotations), 6)
+
         # test the gene_id arg
         annotations[8]['canonical'] = 'YES'
         annotations[1]['gene'] = 'OTHER_GENE1'
         annotations[2]['gene'] = 'OTHER_GENE2'
         self.assertEqual(get_worst_vep_annotation_index(annotations, gene_id='OTHER_GENE1'), 1)
         self.assertEqual(get_worst_vep_annotation_index(annotations, gene_id='OTHER_GENE2'), 2)
+        annotations[8]['canonical'] = 'NO'
+
+
 
     def test_get_worst_vep_annotation(self):
         self.assertEqual(

--- a/xbrowse/annotation/vep_annotations.py
+++ b/xbrowse/annotation/vep_annotations.py
@@ -280,6 +280,12 @@ def get_worst_vep_annotation_index(transcript_annotations, gene_id=None):
         if not annotations:
             raise ValueError("None of the transcripts in %s have gene_id: %s" % (transcript_annotations, gene_id))
 
+    # if 1 or more transcripts is protein-coding, discard the non-protein-coding transcripts
+    protein_coding_transcript_annotations = [
+        (i, ta) for i, ta in annotations if ta['BIOTYPE'] == "protein_coding"]
+    if protein_coding_transcript_annotations:
+        annotations = protein_coding_transcript_annotations
+
     # find the transcript(s) affected with the worst severity
     worst_severity = 10**9   # lower numbers are worse severity
     worst_severity_annotations = []  # a list of worst-severity transcripts

--- a/xbrowse_server/base/management/commands/generate_variant_report.py
+++ b/xbrowse_server/base/management/commands/generate_variant_report.py
@@ -11,7 +11,7 @@ from collections import OrderedDict, defaultdict
 import re
 import urllib2
 
-monkol_muscle_disease_gene_list_2015_03_25 = ['ABHD5', 'ACADS', 'ACADVL', 'ACTA1', 'AGK', 'AGL', 'AGRN', 'ALG13', 'ALG14', 'ALG2', 'ANO5', 'AR', 'ATP2A1', 'B3GALNT2', 'B3GNT1', 'BAG3', 'BIN1', 'C10orf2', 'CAPN3', 'CAV3', 'CCDC78', 'CFL2', 'CHAT', 'CHKB', 'CHRNA1', 'CHRNB1', 'CHRND', 'CHRNE', 'CHRNG', 'CLCN1', 'CNBP', 'CNTN1', 'COL12A1', 'COL6A1', 'COL6A2', 'COL6A3', 'COLQ', 'COX15', 'CPT2', 'CRYAB', 'DAG1', 'DES', 'DMD', 'DMPK', 'DNAJB6', 'DNM2', 'DOK7', 'DOLK', 'DPAGT1', 'DPM1', 'DPM2', 'DPM3', 'DYSF', 'EMD', 'ENO3', 'ETFA', 'ETFB', 'ETFDH', 'FAM111B', 'FHL1', 'FKBP14', 'FKRP', 'FKTN', 'FLNC', 'GAA', 'GBE1', 'GFPT1', 'GMPPB', 'GNE', 'GYG1', 'GYS1', 'HNRNPDL', 'ISCU', 'IGHMBP2', 'ISPD', 'ITGA7', 'KBTBD13', 'KCNJ2', 'KLHL40', 'KLHL41', 'KLHL9', 'LAMA2', 'LAMB2', 'LAMP2', 'LARGE', 'LDB3', 'LDHA', 'LIMS2', 'LMNA', 'LPIN1', 'LRP4', 'MATR3', 'MEGF10', 'MSTN', 'MTM1', 'MTMR14', 'MTTP', 'MUSK', 'MYBPC3', 'MYF6', 'MYH14', 'MYH2', 'MYH3', 'MYH7', 'MYOT', 'NEB', 'OPA1', 'ORAI1', 'PABPN1', 'PFKM', 'PGAM2', 'PGK1', 'PGM1', 'PHKA1', 'PLEC', 'PNPLA2', 'POLG', 'POLG2', 'POMGNT1', 'POMGNT2', 'POMK', 'POMT1', 'POMT2', 'PREPL', 'PRKAG2', 'PTPLA', 'PTRF', 'PYGM', 'RAPSN', 'RRM2B', 'RYR1', 'SCN4A', 'SEPN1', 'SGCA', 'SGCB', 'SGCD', 'SGCG', 'SIL1', 'SLC22A5', 'SLC25A20', 'SLC25A4', 'SLC52A3', 'SMN1', 'STIM1', 'STIM2', 'SUCLA2', 'SYNE1', 'SYNE2', 'TAZ', 'TCAP', 'TIA1', 'TK2', 'TMEM43', 'TMEM5', 'TNNI2', 'TNNT1', 'TNNT3', 'TNPO3', 'TOR1AIP1', 'TPM2', 'TPM3', 'TRAPPC11', 'TRIM32', 'TTN', 'UBA1', 'VAPB', 'VCP', 'VMA21', 'YARS2']
+monkol_muscle_disease_gene_list_2015_03_25 = ['ABHD5', 'ACADS', 'ACADVL', 'ACTA1', 'AGK', 'AGL', 'AGRN', 'ALG13', 'ALG14', 'ALG2', 'ANO5', 'AR', 'ATP2A1', 'B3GALNT2', 'B3GNT1', 'BAG3', 'N1', 'C10orf2', 'CAPN3', 'CAV3', 'CCDC78', 'CFL2', 'CHAT', 'CHKB', 'CHRNA1', 'CHRNB1', 'CHRND', 'CHRNE', 'CHRNG', 'CLCN1', 'CNBP', 'CNTN1', 'COL12A1', 'COL6A1', 'COL6A2', 'COL6A3', 'COLQ', 'COX15', 'CPT2', 'CRYAB', 'DAG1', 'DES', 'DMD', 'DMPK', 'DNAJB6', 'DNM2', 'DOK7', 'DOLK', 'DPAGT1', 'DPM1', 'DPM2', 'DPM3', 'DYSF', 'EMD', 'ENO3', 'ETFA', 'ETFB', 'ETFDH', 'FAM111B', 'FHL1', 'FKBP14', 'FKRP', 'FKTN', 'FLNC', 'GAA', 'GBE1', 'GFPT1', 'GMPPB', 'GNE', 'GYG1', 'GYS1', 'HNRNPDL', 'ISCU', 'IGHMBP2', 'ISPD', 'ITGA7', 'KBTBD13', 'KCNJ2', 'KLHL40', 'KLHL41', 'KLHL9', 'LAMA2', 'LAMB2', 'LAMP2', 'LARGE', 'LDB3', 'LDHA', 'LIMS2', 'LMNA', 'LPIN1', 'LRP4', 'MATR3', 'MEGF10', 'MSTN', 'MTM1', 'MTMR14', 'MTTP', 'MUSK', 'MYBPC3', 'MYF6', 'MYH14', 'MYH2', 'MYH3', 'MYH7', 'MYOT', 'NEB', 'OPA1', 'ORAI1', 'PABPN1', 'PFKM', 'PGAM2', 'PGK1', 'PGM1', 'PHKA1', 'PLEC', 'PNPLA2', 'POLG', 'POLG2', 'POMGNT1', 'POMGNT2', 'POMK', 'POMT1', 'POMT2', 'PREPL', 'PRKAG2', 'PTPLA', 'PTRF', 'PYGM', 'RAPSN', 'RRM2B', 'RYR1', 'SCN4A', 'SEPN1', 'SGCA', 'SGCB', 'SGCD', 'SGCG', 'SIL1', 'SLC22A5', 'SLC25A20', 'SLC25A4', 'SLC52A3', 'SMN1', 'STIM1', 'STIM2', 'SUCLA2', 'SYNE1', 'SYNE2', 'TAZ', 'TCAP', 'TIA1', 'TK2', 'TMEM43', 'TMEM5', 'TNNI2', 'TNNT1', 'TNNT3', 'TNPO3', 'TOR1AIP1', 'TPM2', 'TPM3', 'TRAPPC11', 'TRIM32', 'TTN', 'UBA1', 'VAPB', 'VCP', 'VMA21', 'YARS2']
 
 muscle_disease_gene_list = monkol_muscle_disease_gene_list_2015_03_25
 
@@ -52,10 +52,10 @@ def get_exac_af(chrom, pos, ref, alt):
                 pop_max_af = pop_af
                 pop_max_population = p
 
-    
+
     if matching_exac_variant.INFO['AN_Adj'] != 0:
         global_af = float(matching_exac_variant.INFO['AC_Adj'][matching_exac_variant_i])/float(matching_exac_variant.INFO['AN_Adj'])
-    else: 
+    else:
         assert float(matching_exac_variant.INFO['AC_Adj'][matching_exac_variant_i]) == 0
         global_af = 0
 
@@ -115,8 +115,11 @@ class Command(BaseCommand):
         chrom_without_chr = chrom.replace("chr", "")
 
         annot = v.annotation
-        vep = annot["vep_annotation"][annot["worst_vep_annotation_index"]]  # ea_maf, swissprot, existing_variation, pubmed, aa_maf, ccds, high_inf_pos, cdna_position, canonical, tsl, feature_type, intron, trembl, feature, codons, polyphen, clin_sig, motif_pos, protein_position, afr_maf, amino_acids, cds_position, symbol, uniparc, eur_maf, hgnc_id, consequence, sift, exon, biotype, is_nc, gmaf, motif_name, strand, motif_score_change, distance, hgvsp, ensp, allele, symbol_source, amr_maf, somatic, hgvsc, asn_maf, is_nmd, domains, gene
 
+        from xbrowse.annotation import vep_annotations
+        worst_vep_annotation_index = vep_annotations.get_worst_vep_annotation_index(annot["vep_annotation"])
+
+        vep = annot["vep_annotation"][worst_vep_annotation_index] 
 
         if "symbol" in vep and "consequence"in vep:
             if not gene_name:
@@ -252,6 +255,7 @@ class Command(BaseCommand):
         for vt in VariantTag.objects.filter(project_tag__project=project,
                                             project_tag__tag="REPORT",
                                             family=individual.family):
+
             variants_in_report_and_notes[(vt.xpos, vt.ref, vt.alt)] = ""
 
         for vn in VariantNote.objects.filter(project=project, family=individual.family):


### PR DESCRIPTION
For a given variant, if some of the VEP-annotated transcripts are protein coding, then ignore the non-protein-coding transcripts when chosing the worst-affected transcript